### PR TITLE
feat(rss): group newsfeed articles by their source rss feed

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -378,9 +378,21 @@ const App: React.FC = () => {
                 <p className="text-slate-500 text-lg">No news found. Check your RSS feed settings.</p>
               </div>
             ) : (
-              <div className="space-y-4">
-                {rssArticles.map((article, index) => (
-                  <motion.div
+              <div className="space-y-12">
+                {Object.entries(
+                  rssArticles.reduce((acc, article) => {
+                    if (!acc[article.journal]) acc[article.journal] = [];
+                    acc[article.journal].push(article);
+                    return acc;
+                  }, {} as Record<string, typeof rssArticles>)
+                ).map(([source, articlesInSource]) => (
+                  <div key={source} className="space-y-4">
+                    <h3 className="text-xl font-bold text-slate-700 border-b border-slate-200 pb-2 mb-4">
+                      {source}
+                    </h3>
+                    <div className="space-y-4">
+                      {articlesInSource.map((article, index) => (
+                        <motion.div
                     key={article.id}
                     initial={{ opacity: 0, y: 20 }}
                     animate={{ opacity: 1, y: 0 }}
@@ -457,29 +469,32 @@ const App: React.FC = () => {
                         </div>
                       </div>
 
-                      <AnimatePresence>
-                        {expandedArticleId === article.id && (
-                          <motion.div
-                            initial={{ opacity: 0, height: 0 }}
-                            animate={{ opacity: 1, height: 'auto' }}
-                            exit={{ opacity: 0, height: 0 }}
-                            className="overflow-hidden"
-                          >
-                            <div className="mt-4 pt-4 border-t border-slate-100">
-                              {article.abstract ? (
-                                <div
-                                  className="text-[15px] text-slate-800 leading-relaxed space-y-4 font-serif"
-                                  dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(article.abstract) }}
-                                />
-                              ) : (
-                                <p className="text-sm text-slate-500 italic">No summary available.</p>
-                              )}
-                            </div>
-                          </motion.div>
-                        )}
-                      </AnimatePresence>
+                          <AnimatePresence>
+                            {expandedArticleId === article.id && (
+                              <motion.div
+                                initial={{ opacity: 0, height: 0 }}
+                                animate={{ opacity: 1, height: 'auto' }}
+                                exit={{ opacity: 0, height: 0 }}
+                                className="overflow-hidden"
+                              >
+                                <div className="mt-4 pt-4 border-t border-slate-100">
+                                  {article.abstract ? (
+                                    <div
+                                      className="text-[15px] text-slate-800 leading-relaxed space-y-4 font-serif"
+                                      dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(article.abstract) }}
+                                    />
+                                  ) : (
+                                    <p className="text-sm text-slate-500 italic">No summary available.</p>
+                                  )}
+                                </div>
+                              </motion.div>
+                            )}
+                          </AnimatePresence>
+                        </div>
+                      </motion.div>
+                    ))}
                     </div>
-                  </motion.div>
+                  </div>
                 ))}
               </div>
             )}

--- a/src/services/rss.ts
+++ b/src/services/rss.ts
@@ -23,6 +23,10 @@ export const fetchRssFeeds = async (urls: string[]): Promise<Article[]> => {
       // Simple RSS 2.0 or Atom parser
       const items = xmlDoc.querySelectorAll('item, entry');
 
+      // Try to get feed title for the source
+      const feedTitleNode = xmlDoc.querySelector('channel > title, feed > title');
+      let feedTitle = feedTitleNode?.textContent?.trim() || new URL(url).hostname.replace('www.', '');
+
       items.forEach((item, index) => {
         const title = item.querySelector('title')?.textContent || 'Untitled';
         const description = item.querySelector('description, summary, content')?.textContent || '';
@@ -71,7 +75,7 @@ export const fetchRssFeeds = async (urls: string[]): Promise<Article[]> => {
           title: title.trim(),
           abstract: description.trim(),
           authors: [author.trim()],
-          journal: new URL(url).hostname.replace('www.', ''),
+          journal: feedTitle,
           pubDate: pubDate ? new Date(pubDate).toLocaleDateString() : 'Recent',
           publicationTypes: [],
           imageUrl: imageUrl || undefined


### PR DESCRIPTION
This PR updates the RSS fetching service and the main App rendering logic to visually group RSS articles by their source feed.

1. **`src/services/rss.ts`**: The `fetchRssFeeds` function has been updated to parse the actual feed title (from `<title>` inside `<channel>` or `<feed>`) instead of just falling back to the raw hostname. This parsed feed title is assigned to the `journal` property of the returned articles.
2. **`src/App.tsx`**: The main rendering logic in `App.tsx` now groups the `rssArticles` array by their `journal` property using `reduce`. It renders a distinct section and header (e.g., 'Internal Medicine - Medscape', 'Digital Health Global Blog') for each feed, followed by the respective articles for that source. This ensures that all stories from each individual feed are clearly visible and separated, rather than merged into a single unsorted list.

---
*PR created automatically by Jules for task [13013185436545458937](https://jules.google.com/task/13013185436545458937) started by @mathewjm22*